### PR TITLE
优化：悬赏进入副本识别，应该不会打睡猪8了，如果还有碰到进入高难度机制本请截图反馈

### DIFF
--- a/src/common/funcList/042_悬赏_关闭悬赏封印弹窗.ts
+++ b/src/common/funcList/042_悬赏_关闭悬赏封印弹窗.ts
@@ -1,4 +1,5 @@
-import { InterfaceFuncOrigin, InterfaceFuncOperatorOrigin } from '@/interface/InterfaceFunc';
+import { InterfaceFuncOrigin, InterfaceFuncOperator, InterfaceFuncOperatorOrigin } from '@/interface/InterfaceFunc';
+import { Script } from '@/system/script';
 const normal = -1; //定义常量
 const left = 0;
 const center = 1;
@@ -8,6 +9,20 @@ export class Func042 implements InterfaceFuncOrigin {
 	id = 42;
 	name = '悬赏_关闭悬赏封印弹窗';
 	desc = '请打开悬赏封印弹窗后开启脚本';
+	config = [{
+		desc: '结束后切换方案',
+		config: [{
+			name: 'scheme_switch_enabled',
+			desc: '是否启用',
+			type: 'switch',
+			default: false,
+		}, {
+			name: 'next_scheme',
+			desc: '下一个方案',
+			type: 'scheme',
+			default: '地鬼日常',
+		}]
+	}];
 	operator: InterfaceFuncOperatorOrigin[] = [{
 		desc: [1280, 720,
 			[
@@ -46,5 +61,60 @@ export class Func042 implements InterfaceFuncOrigin {
 		oper: [
 			[left, 1280, 720, 1164, 116, 1189, 143, 500],
 		]
-	}]
+	},
+	// 如果所有任务已经完成
+	{
+		desc: [1280, 720,
+			[
+				[center, 647, 79, 0xe9e2d0],
+				[center, 640, 50, 0x7a5930],
+				[center, 552, 30, 0x484850],
+				[right, 1114, 67, 0x3c3a41],
+				[right, 1161, 86, 0x5d4223],
+				[right, 1179, 134, 0xecdbca],
+				[right, 1173, 593, 0x705a44],
+				[right, 1116, 624, 0x765443],
+				[right, 1170, 623, 0x705847]
+			]
+		],
+		oper: [
+			[left, 1280, 720, 1164, 116, 1189, 143, 500],
+		]
+	}];
+	operatorFunc(thisScript: Script, thisOperator: InterfaceFuncOperator[]): boolean {
+		if (thisScript.oper({
+			name: '悬赏_关闭悬赏封印弹窗',
+			operator: [{
+				desc: thisOperator[0].desc
+			}, {
+				desc: thisOperator[1].desc
+			}]
+		})) {
+			thisScript.helperBridge.regionClick([
+				[1164, 116, 1189, 143, 500]
+			], thisScript.scheme.commonConfig.afterClickDelayRandom);
+			return true
+		} else {
+			// 如果所有任务已经完成,就关闭弹窗后停止脚本或者执行下个方案
+			if (thisScript.oper({
+				name: '悬赏_关闭悬赏封印弹窗',
+				operator: [{
+					desc: thisOperator[2].desc
+				}]
+			})) {
+				thisScript.helperBridge.regionClick([
+					[1164, 116, 1189, 143, 1000]
+				], thisScript.scheme.commonConfig.afterClickDelayRandom);
+				const thisconf = thisScript.scheme.config['42'];
+				if (thisconf && thisconf.scheme_switch_enabled) {
+					thisScript.setCurrentScheme(thisconf.next_scheme as string);
+					thisScript.myToast(`切换方案为[${thisconf.next_scheme}]`);
+					thisScript.rerun();
+				} else {
+					thisScript.doOspPush(thisScript, { text: '脚本已停止，请查看。', before() { thisScript.myToast('脚本即将停止，正在上传数据'); } });
+					thisScript.stop();
+				}
+			}
+		}
+	}
 }

--- a/src/common/funcList/043_悬赏_点击前往任务副本.ts
+++ b/src/common/funcList/043_悬赏_点击前往任务副本.ts
@@ -64,7 +64,7 @@ export class Func043 implements InterfaceFuncOrigin {
 				desc: thisOperator[2].desc
 			}]
 		})) {
-			let unknownStory, challenge;
+			let unknownStory, challengeArr;
 			unknownStory = thisScript.findMultiColor('悬赏_挑战字样') || null;
 			// 如果有挑战副本
 			if (unknownStory) {
@@ -78,8 +78,11 @@ export class Func043 implements InterfaceFuncOrigin {
 				return true
 				// 如果没有挑战副本就寻找秘闻副本
 			} else if (!unknownStory) {
-				challenge = thisScript.findMultiColor('悬赏_秘闻字样') || null;
-				if (challenge) {
+				challengeArr = thisScript.findMultiColorEx('悬赏_秘闻字样') || null;
+				if (challengeArr) {
+					const challenge = challengeArr.reduce((min, obj) => {
+						return obj.y < min.y ? obj : min;
+					});
 					let oper = [
 						[challenge.x + 440, challenge.y, challenge.x + thisOperator[0].oper[0][2] + 440, challenge.y + thisOperator[0].oper[0][3], 4000]
 					];

--- a/src/common/funcList/048_悬赏_杂项.ts
+++ b/src/common/funcList/048_悬赏_杂项.ts
@@ -11,7 +11,7 @@ export class Func048 implements InterfaceFuncOrigin {
 		// 秘闻对话点击
 		desc: [1280, 720,
 			[
-				[center, 422, 715, 0x000000],
+				[center, 500, 715, 0x000000],
 				[center, 612, 715, 0x000000],
 				[center, 773, 715, 0x000000],
 				[center, 830, 716, 0x000000]

--- a/src/common/multiColors.ts
+++ b/src/common/multiColors.ts
@@ -956,7 +956,7 @@ const multiColor: InterfaceMultiColorOrigin = {
         ]
     },
     '悬赏_秘闻字样': {
-        region: [left, 1280, 720, 512, 45, 1256, 428],
+        region: [left, 1280, 720, 512, 160, 1256, 500],
         desc: [
             [1280, 720,
                 [
@@ -1300,7 +1300,7 @@ const multiColor: InterfaceMultiColorOrigin = {
         ]
     },
     "悬赏_庭院检测悬赏图标": {
-        region: [left, 1280, 720, 3, 199, 1272, 477],
+        region: [left, 1280, 720, 0, 88, 1280, 520],
         desc: [
             [1280, 720,
                 [


### PR DESCRIPTION
优化：悬赏进入副本识别，应该不会打睡猪8了，如果还有碰到进入高难度机制本请截图反馈
加大庭院打开悬赏弹窗的识别范围，可以使用高个子式神了
修复：庭院悬赏弹窗在所有任务完成的情况下卡在弹窗那里。现在庭院悬赏弹窗页面如果所有任务已经完成会关闭弹窗后停止脚本，也可在42功能里设置执行下一个方案